### PR TITLE
fix NPE when using prism

### DIFF
--- a/source/FFImageLoading.Maui/CachedImage.cs
+++ b/source/FFImageLoading.Maui/CachedImage.cs
@@ -599,6 +599,9 @@ namespace FFImageLoading.Maui
 		/// (downsampling and transformations variants)</param>
 		public async Task InvalidateCache(ImageSource source, Cache.CacheType cacheType, bool removeSimilar = false)
 		{
+			if (ImageService is null)
+				return;
+
 			if (source is FileImageSource fileImageSource)
 				await ImageService.InvalidateCacheEntryAsync(fileImageSource.File, cacheType, removeSimilar).ConfigureAwait(false);
 
@@ -841,6 +844,12 @@ namespace FFImageLoading.Maui
 		/// <param name="errorPlaceholderSource">Error placeholder source.</param>
 		protected internal virtual void SetupOnBeforeImageLoading(out Work.TaskParameter imageLoader, IImageSourceBinding source, IImageSourceBinding loadingPlaceholderSource, IImageSourceBinding errorPlaceholderSource)
 		{
+			if (ImageService is null)
+			{
+				imageLoader = null;
+				return;
+			}
+
 			if (source.ImageSource == Work.ImageSource.Url)
 			{
 				imageLoader = ImageService.LoadUrl(source.Path, CacheDuration);

--- a/source/FFImageLoading.Maui/CachedImage.cs
+++ b/source/FFImageLoading.Maui/CachedImage.cs
@@ -86,6 +86,8 @@ namespace FFImageLoading.Maui
 			base.OnHandlerChanged();
 
 			ImageService = this.FindMauiContext().Services.GetRequiredService<IImageService<TImageContainer>>();
+
+			ReloadImage();
 		}
 
 		/// <summary>


### PR DESCRIPTION
When using prism the ImageService created by Handler?.MauiContext will be used before OnHandlerChanged.